### PR TITLE
Disable recording admin logins

### DIFF
--- a/ipxcore-addUserIPtoTable.php
+++ b/ipxcore-addUserIPtoTable.php
@@ -4,6 +4,8 @@
 //Released under WTFPL - http://www.wtfpl.net/
 
 function ipxcoreaddIPToList($vars) {
+	
+	if ($_SESSION['adminid']) {return;}
 
 	$userid = $vars['userid'];
 	$ipaddress =  $_SERVER['REMOTE_ADDR'];


### PR DESCRIPTION
I guess this line of code will disable recording when an admin access the client's account (only works if the admin logins using the "Login as Client" button from client summary page. i.e: if admin logins directly from clientarea using email and password of the client, this will execute the rest of the hook).